### PR TITLE
added meta for piControl-ext85yr

### DIFF
--- a/E3SM-1-1-ECA/piControl-ext85yr_r1i1p1f1.json
+++ b/E3SM-1-1-ECA/piControl-ext85yr_r1i1p1f1.json
@@ -1,0 +1,107 @@
+{
+  "#note_source_type": "explanation of what source_type is goes here",
+
+  "source_type": "AOGCM BGC AER",
+
+  "#note_experiment_id": "CMIP6 valid experiment_ids are found in CMIP6_CV.json",
+
+  "experiment_id": "piControl",
+
+  "activity_id": "CMIP",
+
+  "sub_experiment_id": "none",
+
+  "realization_index": "1",
+
+  "initialization_index": "1",
+
+  "physics_index": "1",
+
+  "forcing_index": "1",
+
+  "#note_run_variant": "Text stored in attribute variant_info (recommended, not required description of run variant)",
+
+  "run_variant": "",
+
+  "parent_experiment_id": "piControl-spinup",
+
+  "parent_activity_id": "CMIP",
+
+  "parent_source_id": "E3SM-1-1-ECA",
+
+  "parent_variant_label": "r1i1p1f1",
+
+  "parent_time_units": "days since 0001-01-01",
+
+  "branch_method": "standard",
+
+  "branch_time_in_child": 0.0,
+
+  "branch_time_in_parent": 0.0,
+
+  "#note_institution_id": "institution_id must be registered at https://github.com/WCRP-CMIP/CMIP6_CVs/issues/new ",
+
+  "institution_id": "E3SM-Project",
+
+  "#note_source_id": "source_id (model name) must be registered at https://github.com/WCRP-CMIP/CMIP6_CVs/issues/new ",
+
+  "source_id": "E3SM-1-1-ECA",
+
+  "calendar": "noleap",
+
+  "grid": "data regridded to a CMIP6 standard 1x1 degree lonxlat grid from the native grid using an area-average preserving method.",
+
+  "grid_label": "gr",
+
+  "nominal_resolution": "100 km",
+
+  "license": "CMIP6 model data produced by E3SM is licensed under a Creative Commons Attribution ShareAlike 4.0 International License (https://creativecommons.org/licenses). Consult https://pcmdi.llnl.gov/CMIP6/TermsOfUse for terms of use governing CMIP6 output, including citation requirements and proper acknowledgment. Further information about this data, including some limitations, can be found via the further_info_url (recorded as a global attribute in this file) and at https:///pcmdi.llnl.gov/. The data producers and data providers make no warranty, either express or implied, including, but not limited to, warranties of merchantability and fitness for a particular purpose. All liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law.",
+
+  "#output": "Root directory for output (can be either a relative or full path)",
+
+  "outpath": "CMIP6",
+
+  "#note_optional": " **** The following descriptors are optional and may be set to an empty string ",
+
+  "project PI": "Dave Bader (bader2@llnl.gov)",
+
+  "data contact": "E3SM-DATA-SUPPORT@LISTSERV.LLNL.GOV",
+
+  "history": "Output from 20190308.CNTL_CNPECACNT_20TR.ne30_oECv3.edison",
+
+  "comment": "",
+
+  "references": "Burrows S.M., M.E. Maltrud, X. Yang, Q. Zhu, N. Jeffery, X. Shi, and D.M. Ricciuto, et al. 2019. 'The DOE E3SM coupled model v1.1 biogeochemistry configuration: overview and evaluation of coupled carbon-climate experiments.' Journal of Advances in Modeling Earth Systems. In review; http://e3sm.org'",
+
+  "#note_CV": " **** The following will be obtained from the CV and do not need to be defined here",
+
+  "sub_experiment": "none",
+
+  "institution": "E3SM-Project",
+
+  "source": "E3SM 1.1 ECA (2018)",
+
+  "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
+
+  "_control_vocabulary_file": "CMIP6_CV.json",
+
+  "_AXIS_ENTRY_FILE": "CMIP6_coordinate.json",
+
+  "_FORMULA_VAR_FILE": "CMIP6_formula_terms.json",
+
+  "_cmip6_option": "CMIP6",
+
+  "mip_era": "CMIP6",
+
+  "parent_mip_era": "CMIP6",
+
+  "tracking_prefix": "hdl:21.14100",
+
+  "_history_template": "%s ;rewrote data to be consistent with <activity_id> for variable <variable_id> found in table <table_id>.",
+
+  "#output_path_template": "Template for output path directory using tables keys or global attributes, these should follow the relevant data reference syntax",
+
+  "output_path_template": "<mip_era><activity_id><institution_id><source_id><experiment_id><_member_id><table><variable_id><grid_label><version>",
+
+  "output_file_template": "<variable_id><table><source_id><experiment_id><_member_id><grid_label>"
+}

--- a/E3SM-1-1/piControl-ext85yr-r1i1p1f1.json
+++ b/E3SM-1-1/piControl-ext85yr-r1i1p1f1.json
@@ -1,0 +1,107 @@
+{
+  "#note_source_type": "explanation of what source_type is goes here",
+
+  "source_type": "AOGCM BGC AER",
+
+  "#note_experiment_id": "CMIP6 valid experiment_ids are found in CMIP6_CV.json",
+
+  "experiment_id": "piControl",
+
+  "activity_id": "CMIP",
+
+  "sub_experiment_id": "none",
+
+  "realization_index": "1",
+
+  "initialization_index": "1",
+
+  "physics_index": "1",
+
+  "forcing_index": "1",
+
+  "#note_run_variant": "Text stored in attribute variant_info (recommended, not required description of run variant)",
+
+  "run_variant": "",
+
+  "parent_experiment_id": "piControl-spinup",
+
+  "parent_activity_id": "CMIP",
+
+  "parent_source_id": "E3SM-1-1",
+
+  "parent_variant_label": "r1i1p1f1",
+
+  "parent_time_units": "days since 0001-01-01",
+
+  "branch_method": "standard",
+
+  "branch_time_in_child": 0.0,
+
+  "branch_time_in_parent": 0.0,
+
+  "#note_institution_id": "institution_id must be registered at https://github.com/WCRP-CMIP/CMIP6_CVs/issues/new ",
+
+  "institution_id": "E3SM-Project",
+
+  "#note_source_id": "source_id (model name) must be registered at https://github.com/WCRP-CMIP/CMIP6_CVs/issues/new ",
+
+  "source_id": "E3SM-1-1",
+
+  "calendar": "noleap",
+
+  "grid": "data regridded to a CMIP6 standard 1x1 degree lonxlat grid from the native grid using an area-average preserving method.",
+
+  "grid_label": "gr",
+
+  "nominal_resolution": "100 km",
+
+  "license": "CMIP6 model data produced by E3SM is licensed under a Creative Commons Attribution ShareAlike 4.0 International License (https://creativecommons.org/licenses). Consult https://pcmdi.llnl.gov/CMIP6/TermsOfUse for terms of use governing CMIP6 output, including citation requirements and proper acknowledgment. Further information about this data, including some limitations, can be found via the further_info_url (recorded as a global attribute in this file) and at https:///pcmdi.llnl.gov/. The data producers and data providers make no warranty, either express or implied, including, but not limited to, warranties of merchantability and fitness for a particular purpose. All liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law.",
+
+  "#output": "Root directory for output (can be either a relative or full path)",
+
+  "outpath": "CMIP6",
+
+  "#note_optional": " **** The following descriptors are optional and may be set to an empty string ",
+
+  "project PI": "Dave Bader (bader2@llnl.gov)",
+
+  "data contact": "E3SM-DATA-SUPPORT@LISTSERV.LLNL.GOV",
+
+  "history": "Output from 20181217.CNTL_CNPCTC1850_OIBGC.ne30_oECv3.edison",
+
+  "comment": "",
+
+  "references": "Burrows S.M., M.E. Maltrud, X. Yang, Q. Zhu, N. Jeffery, X. Shi, and D.M. Ricciuto, et al. 2019. 'The DOE E3SM coupled model v1.1 biogeochemistry configuration: overview and evaluation of coupled carbon-climate experiments.' Journal of Advances in Modeling Earth Systems. In review; http://e3sm.org'",
+
+  "#note_CV": " **** The following will be obtained from the CV and do not need to be defined here",
+
+  "sub_experiment": "none",
+
+  "institution": "E3SM-Project",
+
+  "source": "E3SM 1.1 (2019): aerosol: MAM4 with resuspension, marine organics, and secondary organics (same grid as atmos) atmos: EAM (v1.1, cubed sphere spectral-element grid; 5400 elements with p=3; 1 deg average grid spacing; 90 x 90 x 6 longitude/latitude/cubeface; 72 levels; top level 0.1 hPa) atmosChem: Troposphere specified oxidants for aerosols. Stratosphere linearized interactive ozone (LINOZ v2) (same grid as atmos) land: ELM (v1.1, same grid as atmos; active biogeochemistry using the Converging Trophic Cascade plant and soil carbon and nutrient mechanisms to represent carbon, nitrogen and phosphorus cycles), MOSART (v1.1, 0.5 degree latitude/longitude grid) landIce: none ocean: MPAS-Ocean (v6.0, oEC60to30 unstructured SVTs mesh with 235160 cells and 714274 edges, variable resolution 60 km to 30 km; 60 levels; top grid cell 0-10 m) ocnBgchem: BEC (Biogeochemical Elemental Cycling model, NPZD-type with C/N/",
+
+  "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
+
+  "_control_vocabulary_file": "CMIP6_CV.json",
+
+  "_AXIS_ENTRY_FILE": "CMIP6_coordinate.json",
+
+  "_FORMULA_VAR_FILE": "CMIP6_formula_terms.json",
+
+  "_cmip6_option": "CMIP6",
+
+  "mip_era": "CMIP6",
+
+  "parent_mip_era": "CMIP6",
+
+  "tracking_prefix": "hdl:21.14100",
+
+  "_history_template": "%s ;rewrote data to be consistent with <activity_id> for variable <variable_id> found in table <table_id>.",
+
+  "#output_path_template": "Template for output path directory using tables keys or global attributes, these should follow the relevant data reference syntax",
+
+  "output_path_template": "<mip_era><activity_id><institution_id><source_id><experiment_id><_member_id><table><variable_id><grid_label><version>",
+
+  "output_file_template": "<variable_id><table><source_id><experiment_id><_member_id><grid_label>"
+}


### PR DESCRIPTION
I merely copied the parent metafiles (piControl to piControl-ext85yr) so they would be found by the auto-generated loader.