### PR TITLE
neglected check-in of Large_Ensemble references adjusted.

### DIFF
--- a/E3SM-1-0-LE/ssp370_r10i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r10i2p2f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Stevenson, S., Huang, X., Zhao, Y., Di Lorenzo, E., Newman, M., van Roekel, L., Xu, T., & Capotondi, A. 2023: Ensemble Spread Behavior in Coupled Climate Models: Insights from the Energy Exascale Earth System Model version 1, JAMES; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-1-0-LE/ssp370_r11i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r11i2p2f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Stevenson, S., Huang, X., Zhao, Y., Di Lorenzo, E., Newman, M., van Roekel, L., Xu, T., & Capotondi, A. 2023: Ensemble Spread Behavior in Coupled Climate Models: Insights from the Energy Exascale Earth System Model version 1, JAMES; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-1-0-LE/ssp370_r12i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r12i2p2f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Stevenson, S., Huang, X., Zhao, Y., Di Lorenzo, E., Newman, M., van Roekel, L., Xu, T., & Capotondi, A. 2023: Ensemble Spread Behavior in Coupled Climate Models: Insights from the Energy Exascale Earth System Model version 1, JAMES; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-1-0-LE/ssp370_r13i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r13i2p2f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Stevenson, S., Huang, X., Zhao, Y., Di Lorenzo, E., Newman, M., van Roekel, L., Xu, T., & Capotondi, A. 2023: Ensemble Spread Behavior in Coupled Climate Models: Insights from the Energy Exascale Earth System Model version 1, JAMES; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-1-0-LE/ssp370_r14i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r14i2p2f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Stevenson, S., Huang, X., Zhao, Y., Di Lorenzo, E., Newman, M., van Roekel, L., Xu, T., & Capotondi, A. 2023: Ensemble Spread Behavior in Coupled Climate Models: Insights from the Energy Exascale Earth System Model version 1, JAMES; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-1-0-LE/ssp370_r15i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r15i2p2f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Stevenson, S., Huang, X., Zhao, Y., Di Lorenzo, E., Newman, M., van Roekel, L., Xu, T., & Capotondi, A. 2023: Ensemble Spread Behavior in Coupled Climate Models: Insights from the Energy Exascale Earth System Model version 1, JAMES; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-1-0-LE/ssp370_r16i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r16i2p2f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Stevenson, S., Huang, X., Zhao, Y., Di Lorenzo, E., Newman, M., van Roekel, L., Xu, T., & Capotondi, A. 2023: Ensemble Spread Behavior in Coupled Climate Models: Insights from the Energy Exascale Earth System Model version 1, JAMES; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-1-0-LE/ssp370_r17i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r17i2p2f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Stevenson, S., Huang, X., Zhao, Y., Di Lorenzo, E., Newman, M., van Roekel, L., Xu, T., & Capotondi, A. 2023: Ensemble Spread Behavior in Coupled Climate Models: Insights from the Energy Exascale Earth System Model version 1, JAMES; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-1-0-LE/ssp370_r18i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r18i2p2f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Stevenson, S., Huang, X., Zhao, Y., Di Lorenzo, E., Newman, M., van Roekel, L., Xu, T., & Capotondi, A. 2023: Ensemble Spread Behavior in Coupled Climate Models: Insights from the Energy Exascale Earth System Model version 1, JAMES; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-1-0-LE/ssp370_r19i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r19i2p2f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Stevenson, S., Huang, X., Zhao, Y., Di Lorenzo, E., Newman, M., van Roekel, L., Xu, T., & Capotondi, A. 2023: Ensemble Spread Behavior in Coupled Climate Models: Insights from the Energy Exascale Earth System Model version 1, JAMES; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-1-0-LE/ssp370_r1i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r1i2p2f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Stevenson, S., Huang, X., Zhao, Y., Di Lorenzo, E., Newman, M., van Roekel, L., Xu, T., & Capotondi, A. 2023: Ensemble Spread Behavior in Coupled Climate Models: Insights from the Energy Exascale Earth System Model version 1, JAMES; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-1-0-LE/ssp370_r20i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r20i2p2f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Stevenson, S., Huang, X., Zhao, Y., Di Lorenzo, E., Newman, M., van Roekel, L., Xu, T., & Capotondi, A. 2023: Ensemble Spread Behavior in Coupled Climate Models: Insights from the Energy Exascale Earth System Model version 1, JAMES; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-1-0-LE/ssp370_r2i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r2i2p2f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Stevenson, S., Huang, X., Zhao, Y., Di Lorenzo, E., Newman, M., van Roekel, L., Xu, T., & Capotondi, A. 2023: Ensemble Spread Behavior in Coupled Climate Models: Insights from the Energy Exascale Earth System Model version 1, JAMES; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-1-0-LE/ssp370_r3i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r3i2p2f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Stevenson, S., Huang, X., Zhao, Y., Di Lorenzo, E., Newman, M., van Roekel, L., Xu, T., & Capotondi, A. 2023: Ensemble Spread Behavior in Coupled Climate Models: Insights from the Energy Exascale Earth System Model version 1, JAMES; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-1-0-LE/ssp370_r4i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r4i2p2f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Stevenson, S., Huang, X., Zhao, Y., Di Lorenzo, E., Newman, M., van Roekel, L., Xu, T., & Capotondi, A. 2023: Ensemble Spread Behavior in Coupled Climate Models: Insights from the Energy Exascale Earth System Model version 1, JAMES; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-1-0-LE/ssp370_r5i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r5i2p2f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Stevenson, S., Huang, X., Zhao, Y., Di Lorenzo, E., Newman, M., van Roekel, L., Xu, T., & Capotondi, A. 2023: Ensemble Spread Behavior in Coupled Climate Models: Insights from the Energy Exascale Earth System Model version 1, JAMES; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-1-0-LE/ssp370_r6i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r6i2p2f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Stevenson, S., Huang, X., Zhao, Y., Di Lorenzo, E., Newman, M., van Roekel, L., Xu, T., & Capotondi, A. 2023: Ensemble Spread Behavior in Coupled Climate Models: Insights from the Energy Exascale Earth System Model version 1, JAMES; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-1-0-LE/ssp370_r7i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r7i2p2f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Stevenson, S., Huang, X., Zhao, Y., Di Lorenzo, E., Newman, M., van Roekel, L., Xu, T., & Capotondi, A. 2023: Ensemble Spread Behavior in Coupled Climate Models: Insights from the Energy Exascale Earth System Model version 1, JAMES; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-1-0-LE/ssp370_r8i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r8i2p2f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Stevenson, S., Huang, X., Zhao, Y., Di Lorenzo, E., Newman, M., van Roekel, L., Xu, T., & Capotondi, A. 2023: Ensemble Spread Behavior in Coupled Climate Models: Insights from the Energy Exascale Earth System Model version 1, JAMES; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-1-0-LE/ssp370_r9i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r9i2p2f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Stevenson, S., Huang, X., Zhao, Y., Di Lorenzo, E., Newman, M., van Roekel, L., Xu, T., & Capotondi, A. 2023: Ensemble Spread Behavior in Coupled Climate Models: Insights from the Energy Exascale Earth System Model version 1, JAMES; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/historical_r10i1p1f1.json
+++ b/E3SM-2-0-LE/historical_r10i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/historical_r11i1p1f1.json
+++ b/E3SM-2-0-LE/historical_r11i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/historical_r12i1p1f1.json
+++ b/E3SM-2-0-LE/historical_r12i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/historical_r13i1p1f1.json
+++ b/E3SM-2-0-LE/historical_r13i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/historical_r14i1p1f1.json
+++ b/E3SM-2-0-LE/historical_r14i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/historical_r15i1p1f1.json
+++ b/E3SM-2-0-LE/historical_r15i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/historical_r16i1p1f1.json
+++ b/E3SM-2-0-LE/historical_r16i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/historical_r17i1p1f1.json
+++ b/E3SM-2-0-LE/historical_r17i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/historical_r18i1p1f1.json
+++ b/E3SM-2-0-LE/historical_r18i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/historical_r19i1p1f1.json
+++ b/E3SM-2-0-LE/historical_r19i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/historical_r1i1p1f1.json
+++ b/E3SM-2-0-LE/historical_r1i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/historical_r20i1p1f1.json
+++ b/E3SM-2-0-LE/historical_r20i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/historical_r21i1p1f1.json
+++ b/E3SM-2-0-LE/historical_r21i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/historical_r2i1p1f1.json
+++ b/E3SM-2-0-LE/historical_r2i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/historical_r3i1p1f1.json
+++ b/E3SM-2-0-LE/historical_r3i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/historical_r4i1p1f1.json
+++ b/E3SM-2-0-LE/historical_r4i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/historical_r5i1p1f1.json
+++ b/E3SM-2-0-LE/historical_r5i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/historical_r6i1p1f1.json
+++ b/E3SM-2-0-LE/historical_r6i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/historical_r7i1p1f1.json
+++ b/E3SM-2-0-LE/historical_r7i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/historical_r8i1p1f1.json
+++ b/E3SM-2-0-LE/historical_r8i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/historical_r9i1p1f1.json
+++ b/E3SM-2-0-LE/historical_r9i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/ssp370_r10i1p1f1.json
+++ b/E3SM-2-0-LE/ssp370_r10i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/ssp370_r11i1p1f1.json
+++ b/E3SM-2-0-LE/ssp370_r11i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/ssp370_r12i1p1f1.json
+++ b/E3SM-2-0-LE/ssp370_r12i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/ssp370_r13i1p1f1.json
+++ b/E3SM-2-0-LE/ssp370_r13i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/ssp370_r14i1p1f1.json
+++ b/E3SM-2-0-LE/ssp370_r14i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/ssp370_r15i1p1f1.json
+++ b/E3SM-2-0-LE/ssp370_r15i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/ssp370_r16i1p1f1.json
+++ b/E3SM-2-0-LE/ssp370_r16i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/ssp370_r17i1p1f1.json
+++ b/E3SM-2-0-LE/ssp370_r17i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/ssp370_r18i1p1f1.json
+++ b/E3SM-2-0-LE/ssp370_r18i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/ssp370_r19i1p1f1.json
+++ b/E3SM-2-0-LE/ssp370_r19i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/ssp370_r1i1p1f1.json
+++ b/E3SM-2-0-LE/ssp370_r1i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/ssp370_r20i1p1f1.json
+++ b/E3SM-2-0-LE/ssp370_r20i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/ssp370_r21i1p1f1.json
+++ b/E3SM-2-0-LE/ssp370_r21i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/ssp370_r2i1p1f1.json
+++ b/E3SM-2-0-LE/ssp370_r2i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/ssp370_r3i1p1f1.json
+++ b/E3SM-2-0-LE/ssp370_r3i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/ssp370_r4i1p1f1.json
+++ b/E3SM-2-0-LE/ssp370_r4i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/ssp370_r5i1p1f1.json
+++ b/E3SM-2-0-LE/ssp370_r5i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/ssp370_r6i1p1f1.json
+++ b/E3SM-2-0-LE/ssp370_r6i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/ssp370_r7i1p1f1.json
+++ b/E3SM-2-0-LE/ssp370_r7i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/ssp370_r8i1p1f1.json
+++ b/E3SM-2-0-LE/ssp370_r8i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 

--- a/E3SM-2-0-LE/ssp370_r9i1p1f1.json
+++ b/E3SM-2-0-LE/ssp370_r9i1p1f1.json
@@ -75,7 +75,7 @@
 
   "comment": "",
 
-  "references": "Golaz, J.-C., L. P. Van Roekel, X. Zheng and co-authors, 2022: The DOE E3SM Model Version 2: Overview of the physical model and initial model evaluation. JAMES, doi: 10.1029/2022MS003156; http://e3sm.org; Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A., et al, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, et al, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication",
+  "references": "Fasullo, J.T., J.-C. Golaz, J. M. Caron, N. Rosenbloom G. A. Meehl, G. Strand, S. Glanville, S. Stevenson, M. Molina, and C. A. Shields, C. Zhang, J. Benedict, T.Bartoletti, 2023, An Overview of the E3SM version 2 Large Ensemble and Comparison to other E3SM and CESM Large Ensembles, Earth Sys. Dyn., in review concurrent to data publication; Fasullo, J.T., J. M. Caron, Adam Phillips, Hui Li, Jadwiga H. Richter, Richard B. Neale, N. Rosenbloom, G. Strand, S. Glanville, Y. Li, F. Lehner, G. Meehl, J.-C. Golaz, P. Ullrich, J. Lee, Julie Arblaster, 2023, Modes of Variability in E3SM and CESM Large Ensembles, J. Cllim., in review concurrent to data publication.",
 
   "#note_CMIP6": " **** The following are set correctly for CMIP6 and should not normally need editing",
 


### PR DESCRIPTION
Recent check-in of 1 v2_1 amip metadata file revealed (upon master pull) that all of the 1-0-LE and 2-0-LE metadata references had reverted to old values (not the active ones used in CMIP6 operations).  I assume they had never been merged to master.  I intend to rectify this by using the active metadata files employed in the LE CMIP6 generation.