### PR TITLE
Corrected parent_experiment_id, parent_activity_id, and source_type

### DIFF
--- a/E3SM-2-1/amip_r1i1p1f1.json
+++ b/E3SM-2-1/amip_r1i1p1f1.json
@@ -1,7 +1,7 @@
 {
   "#note_source_type": "explanation of what source_type is goes here",
 
-  "source_type": "AOGCM AER",
+  "source_type": "AGCM AER",
 
   "#note_experiment_id": "CMIP6 valid experiment_ids are found in CMIP6_CV.json",
 
@@ -23,9 +23,9 @@
 
   "run_variant": "",
 
-  "parent_experiment_id": "piControl",
+  "parent_experiment_id": "no parent",
 
-  "parent_activity_id": "CMIP",
+  "parent_activity_id": "no parent",
 
   "parent_source_id": "E3SM-2-1",
 


### PR DESCRIPTION
Corrected parent_experiment_id, parent_activity_id, and source_type for amip metadata - late-arriving archive.