### PR TITLE
Updated E3SM-1-0-LE ssp370 parent_variant_labels

### DIFF
--- a/E3SM-1-0-LE/ssp370_r10i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r10i2p2f1.json
@@ -29,7 +29,7 @@
 
   "parent_source_id": "E3SM-1-0",
 
-  "parent_variant_label": "r1i1p1f1",
+  "parent_variant_label": "r10i2p2f1",
 
   "parent_time_units": "days since 1850-01-01",
 

--- a/E3SM-1-0-LE/ssp370_r11i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r11i2p2f1.json
@@ -29,7 +29,7 @@
 
   "parent_source_id": "E3SM-1-0",
 
-  "parent_variant_label": "r1i1p1f1",
+  "parent_variant_label": "r11i2p2f1",
 
   "parent_time_units": "days since 1850-01-01",
 

--- a/E3SM-1-0-LE/ssp370_r12i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r12i2p2f1.json
@@ -29,7 +29,7 @@
 
   "parent_source_id": "E3SM-1-0",
 
-  "parent_variant_label": "r1i1p1f1",
+  "parent_variant_label": "r12i2p2f1",
 
   "parent_time_units": "days since 1850-01-01",
 

--- a/E3SM-1-0-LE/ssp370_r13i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r13i2p2f1.json
@@ -29,7 +29,7 @@
 
   "parent_source_id": "E3SM-1-0",
 
-  "parent_variant_label": "r1i1p1f1",
+  "parent_variant_label": "r13i2p2f1",
 
   "parent_time_units": "days since 1850-01-01",
 

--- a/E3SM-1-0-LE/ssp370_r14i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r14i2p2f1.json
@@ -29,7 +29,7 @@
 
   "parent_source_id": "E3SM-1-0",
 
-  "parent_variant_label": "r1i1p1f1",
+  "parent_variant_label": "r14i2p2f1",
 
   "parent_time_units": "days since 1850-01-01",
 

--- a/E3SM-1-0-LE/ssp370_r15i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r15i2p2f1.json
@@ -29,7 +29,7 @@
 
   "parent_source_id": "E3SM-1-0",
 
-  "parent_variant_label": "r1i1p1f1",
+  "parent_variant_label": "r15i2p2f1",
 
   "parent_time_units": "days since 1850-01-01",
 

--- a/E3SM-1-0-LE/ssp370_r16i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r16i2p2f1.json
@@ -29,7 +29,7 @@
 
   "parent_source_id": "E3SM-1-0",
 
-  "parent_variant_label": "r1i1p1f1",
+  "parent_variant_label": "r16i2p2f1",
 
   "parent_time_units": "days since 1850-01-01",
 

--- a/E3SM-1-0-LE/ssp370_r17i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r17i2p2f1.json
@@ -29,7 +29,7 @@
 
   "parent_source_id": "E3SM-1-0",
 
-  "parent_variant_label": "r1i1p1f1",
+  "parent_variant_label": "r17i2p2f1",
 
   "parent_time_units": "days since 1850-01-01",
 

--- a/E3SM-1-0-LE/ssp370_r18i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r18i2p2f1.json
@@ -29,7 +29,7 @@
 
   "parent_source_id": "E3SM-1-0",
 
-  "parent_variant_label": "r1i1p1f1",
+  "parent_variant_label": "r18i2p2f1",
 
   "parent_time_units": "days since 1850-01-01",
 

--- a/E3SM-1-0-LE/ssp370_r19i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r19i2p2f1.json
@@ -29,7 +29,7 @@
 
   "parent_source_id": "E3SM-1-0",
 
-  "parent_variant_label": "r1i1p1f1",
+  "parent_variant_label": "r19i2p2f1",
 
   "parent_time_units": "days since 1850-01-01",
 

--- a/E3SM-1-0-LE/ssp370_r1i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r1i2p2f1.json
@@ -29,7 +29,7 @@
 
   "parent_source_id": "E3SM-1-0",
 
-  "parent_variant_label": "r1i1p1f1",
+  "parent_variant_label": "r1i2p2f1",
 
   "parent_time_units": "days since 1850-01-01",
 

--- a/E3SM-1-0-LE/ssp370_r20i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r20i2p2f1.json
@@ -29,7 +29,7 @@
 
   "parent_source_id": "E3SM-1-0",
 
-  "parent_variant_label": "r1i1p1f1",
+  "parent_variant_label": "r20i2p2f1",
 
   "parent_time_units": "days since 1850-01-01",
 

--- a/E3SM-1-0-LE/ssp370_r2i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r2i2p2f1.json
@@ -29,7 +29,7 @@
 
   "parent_source_id": "E3SM-1-0",
 
-  "parent_variant_label": "r1i1p1f1",
+  "parent_variant_label": "r2i2p2f1",
 
   "parent_time_units": "days since 1850-01-01",
 

--- a/E3SM-1-0-LE/ssp370_r3i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r3i2p2f1.json
@@ -29,7 +29,7 @@
 
   "parent_source_id": "E3SM-1-0",
 
-  "parent_variant_label": "r1i1p1f1",
+  "parent_variant_label": "r3i2p2f1",
 
   "parent_time_units": "days since 1850-01-01",
 

--- a/E3SM-1-0-LE/ssp370_r4i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r4i2p2f1.json
@@ -29,7 +29,7 @@
 
   "parent_source_id": "E3SM-1-0",
 
-  "parent_variant_label": "r1i1p1f1",
+  "parent_variant_label": "r4i2p2f1",
 
   "parent_time_units": "days since 1850-01-01",
 

--- a/E3SM-1-0-LE/ssp370_r5i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r5i2p2f1.json
@@ -29,7 +29,7 @@
 
   "parent_source_id": "E3SM-1-0",
 
-  "parent_variant_label": "r1i1p1f1",
+  "parent_variant_label": "r5i2p2f1",
 
   "parent_time_units": "days since 1850-01-01",
 

--- a/E3SM-1-0-LE/ssp370_r6i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r6i2p2f1.json
@@ -29,7 +29,7 @@
 
   "parent_source_id": "E3SM-1-0",
 
-  "parent_variant_label": "r1i1p1f1",
+  "parent_variant_label": "r6i2p2f1",
 
   "parent_time_units": "days since 1850-01-01",
 

--- a/E3SM-1-0-LE/ssp370_r7i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r7i2p2f1.json
@@ -29,7 +29,7 @@
 
   "parent_source_id": "E3SM-1-0",
 
-  "parent_variant_label": "r1i1p1f1",
+  "parent_variant_label": "r7i2p2f1",
 
   "parent_time_units": "days since 1850-01-01",
 

--- a/E3SM-1-0-LE/ssp370_r8i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r8i2p2f1.json
@@ -29,7 +29,7 @@
 
   "parent_source_id": "E3SM-1-0",
 
-  "parent_variant_label": "r1i1p1f1",
+  "parent_variant_label": "r8i2p2f1",
 
   "parent_time_units": "days since 1850-01-01",
 

--- a/E3SM-1-0-LE/ssp370_r9i2p2f1.json
+++ b/E3SM-1-0-LE/ssp370_r9i2p2f1.json
@@ -29,7 +29,7 @@
 
   "parent_source_id": "E3SM-1-0",
 
-  "parent_variant_label": "r1i1p1f1",
+  "parent_variant_label": "r9i2p2f1",
 
   "parent_time_units": "days since 1850-01-01",
 


### PR DESCRIPTION
Previously, each ssp370 metadata had  parent_variant_label "r1i1p1f1", when each should have indicated its own historical parent variant (reflected in the ssp370 metadata filename).